### PR TITLE
Fix bug where visitors can claim plots

### DIFF
--- a/OREPyUtils/Plots/Frontend.py
+++ b/OREPyUtils/Plots/Frontend.py
@@ -18,6 +18,7 @@ Permission nodes:
 ore.plot.give
 ore.plot.claimas
 ore.plot.generate
+ore.plot.claim
 """
 
 """
@@ -478,6 +479,10 @@ def OnCommandPclaim(sender, args):
 	manager = GetManager_ByPlayer(sender)
 
 	x, y = GetPlot(sender, args, manager)
+	
+	if not sender.hasPermission("ore.plot.claim"):
+		SendError(sender, "You do not have permission to do this")
+		return True
 
 	try:
 


### PR DESCRIPTION
NOTE!!!! Give the permission ore.plot.claim to everyone except visitors, guests and testificates in the PEX permissions file.

Yeah, i decided to contribute since this bug was annoying me.